### PR TITLE
settings fix for exceptions over Timeout empty xml element

### DIFF
--- a/CrmConnectionProjects/McTools.Xrm.Connection.WinForms/ConnectionSelector.cs
+++ b/CrmConnectionProjects/McTools.Xrm.Connection.WinForms/ConnectionSelector.cs
@@ -88,12 +88,12 @@ namespace McTools.Xrm.Connection.WinForms
 
                 foreach (ConnectionDetail detail in details)
                 {
-                    var item = new ListViewItem(detail.ConnectionName);
+                    var item = new ListViewItem(detail.ConnectionName ?? "No name"); //throws out of memory exception if null
                     item.SubItems.Add(detail.ServerName);
                     item.SubItems.Add(detail.Organization);
                     item.SubItems.Add(string.IsNullOrEmpty(detail.UserDomain) ? detail.UserName : $"{detail.UserDomain}\\{detail.UserName}");
                     item.SubItems.Add(detail.OrganizationVersion);
-                    item.SubItems.Add(detail.SolutionName);
+                    item.SubItems.Add(detail.SolutionName ?? "No name");
                     item.Tag = detail;
                     item.ImageIndex = GetImageIndex(detail);
 

--- a/CrmConnectionProjects/McTools.Xrm.Connection.WinForms/ConnectionSelector.designer.cs
+++ b/CrmConnectionProjects/McTools.Xrm.Connection.WinForms/ConnectionSelector.designer.cs
@@ -60,10 +60,10 @@
             // bValidate
             // 
             this.bValidate.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.bValidate.Location = new System.Drawing.Point(580, 105);
-            this.bValidate.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
+            this.bValidate.Location = new System.Drawing.Point(773, 129);
+            this.bValidate.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.bValidate.Name = "bValidate";
-            this.bValidate.Size = new System.Drawing.Size(74, 23);
+            this.bValidate.Size = new System.Drawing.Size(99, 28);
             this.bValidate.TabIndex = 3;
             this.bValidate.Text = "Save";
             this.bValidate.UseVisualStyleBackColor = true;
@@ -73,10 +73,10 @@
             // 
             this.bCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.bCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.bCancel.Location = new System.Drawing.Point(662, 105);
-            this.bCancel.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
+            this.bCancel.Location = new System.Drawing.Point(883, 129);
+            this.bCancel.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.bCancel.Name = "bCancel";
-            this.bCancel.Size = new System.Drawing.Size(74, 23);
+            this.bCancel.Size = new System.Drawing.Size(99, 28);
             this.bCancel.TabIndex = 4;
             this.bCancel.Text = "Cancel";
             this.bCancel.UseVisualStyleBackColor = true;
@@ -96,10 +96,10 @@
             this.lvConnections.GridLines = true;
             this.lvConnections.HideSelection = false;
             this.lvConnections.LabelEdit = true;
-            this.lvConnections.Location = new System.Drawing.Point(4, 4);
-            this.lvConnections.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
+            this.lvConnections.Location = new System.Drawing.Point(5, 5);
+            this.lvConnections.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.lvConnections.Name = "lvConnections";
-            this.lvConnections.Size = new System.Drawing.Size(736, 243);
+            this.lvConnections.Size = new System.Drawing.Size(982, 299);
             this.lvConnections.TabIndex = 2;
             this.lvConnections.UseCompatibleStateImageBehavior = false;
             this.lvConnections.View = System.Windows.Forms.View.Details;
@@ -142,6 +142,7 @@
             // menu
             // 
             this.menu.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
+            this.menu.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.menu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.tsbNewConnection,
             this.tsbUpdateConnection,
@@ -150,7 +151,7 @@
             this.menu.Location = new System.Drawing.Point(0, 0);
             this.menu.Name = "menu";
             this.menu.Padding = new System.Windows.Forms.Padding(0);
-            this.menu.Size = new System.Drawing.Size(744, 25);
+            this.menu.Size = new System.Drawing.Size(992, 31);
             this.menu.TabIndex = 1;
             this.menu.Text = "tsMain";
             // 
@@ -159,7 +160,7 @@
             this.tsbNewConnection.Image = ((System.Drawing.Image)(resources.GetObject("tsbNewConnection.Image")));
             this.tsbNewConnection.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbNewConnection.Name = "tsbNewConnection";
-            this.tsbNewConnection.Size = new System.Drawing.Size(114, 22);
+            this.tsbNewConnection.Size = new System.Drawing.Size(140, 28);
             this.tsbNewConnection.Text = "New connection";
             this.tsbNewConnection.Click += new System.EventHandler(this.tsbNewConnection_Click);
             // 
@@ -168,7 +169,7 @@
             this.tsbUpdateConnection.Image = ((System.Drawing.Image)(resources.GetObject("tsbUpdateConnection.Image")));
             this.tsbUpdateConnection.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbUpdateConnection.Name = "tsbUpdateConnection";
-            this.tsbUpdateConnection.Size = new System.Drawing.Size(128, 22);
+            this.tsbUpdateConnection.Size = new System.Drawing.Size(159, 28);
             this.tsbUpdateConnection.Text = "Update connection";
             this.tsbUpdateConnection.Click += new System.EventHandler(this.tsbUpdateConnection_Click);
             // 
@@ -177,7 +178,7 @@
             this.tsbDeleteConnection.Image = ((System.Drawing.Image)(resources.GetObject("tsbDeleteConnection.Image")));
             this.tsbDeleteConnection.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbDeleteConnection.Name = "tsbDeleteConnection";
-            this.tsbDeleteConnection.Size = new System.Drawing.Size(123, 22);
+            this.tsbDeleteConnection.Size = new System.Drawing.Size(154, 28);
             this.tsbDeleteConnection.Text = "Delete connection";
             this.tsbDeleteConnection.Click += new System.EventHandler(this.tsbDeleteConnection_Click);
             // 
@@ -186,7 +187,7 @@
             this.tsbUpdateSolution.Image = global::McTools.Xrm.Connection.WinForms.Properties.Resources.ico_16_7100;
             this.tsbUpdateSolution.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbUpdateSolution.Name = "tsbUpdateSolution";
-            this.tsbUpdateSolution.Size = new System.Drawing.Size(112, 22);
+            this.tsbUpdateSolution.Size = new System.Drawing.Size(141, 28);
             this.tsbUpdateSolution.Text = "Update Solution";
             this.tsbUpdateSolution.ToolTipText = "Update solution for selected connection";
             this.tsbUpdateSolution.Click += new System.EventHandler(this.tsbUpdateSolution_Click);
@@ -203,27 +204,29 @@
             this.pnlFooter.Controls.Add(this.bPublish);
             this.pnlFooter.Controls.Add(this.bValidate);
             this.pnlFooter.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.pnlFooter.Location = new System.Drawing.Point(0, 276);
-            this.pnlFooter.Margin = new System.Windows.Forms.Padding(2);
+            this.pnlFooter.Location = new System.Drawing.Point(0, 340);
+            this.pnlFooter.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.pnlFooter.Name = "pnlFooter";
-            this.pnlFooter.Size = new System.Drawing.Size(744, 134);
+            this.pnlFooter.Size = new System.Drawing.Size(992, 165);
             this.pnlFooter.TabIndex = 5;
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(10, 83);
+            this.label1.Location = new System.Drawing.Point(13, 102);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(105, 13);
+            this.label1.Size = new System.Drawing.Size(136, 17);
             this.label1.TabIndex = 10;
             this.label1.Text = "Selected connection";
             // 
             // cbExtendedLog
             // 
             this.cbExtendedLog.AutoSize = true;
-            this.cbExtendedLog.Location = new System.Drawing.Point(12, 53);
+            this.cbExtendedLog.Location = new System.Drawing.Point(16, 65);
+            this.cbExtendedLog.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.cbExtendedLog.Name = "cbExtendedLog";
-            this.cbExtendedLog.Size = new System.Drawing.Size(88, 17);
+            this.cbExtendedLog.Size = new System.Drawing.Size(112, 21);
             this.cbExtendedLog.TabIndex = 9;
             this.cbExtendedLog.Text = "Extended log";
             this.cbExtendedLog.UseVisualStyleBackColor = true;
@@ -231,9 +234,10 @@
             // cbIgnoreExtensions
             // 
             this.cbIgnoreExtensions.AutoSize = true;
-            this.cbIgnoreExtensions.Location = new System.Drawing.Point(12, 29);
+            this.cbIgnoreExtensions.Location = new System.Drawing.Point(16, 36);
+            this.cbIgnoreExtensions.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.cbIgnoreExtensions.Name = "cbIgnoreExtensions";
-            this.cbIgnoreExtensions.Size = new System.Drawing.Size(193, 17);
+            this.cbIgnoreExtensions.Size = new System.Drawing.Size(250, 21);
             this.cbIgnoreExtensions.TabIndex = 8;
             this.cbIgnoreExtensions.Text = "Search with and without extensions";
             this.cbIgnoreExtensions.UseVisualStyleBackColor = true;
@@ -241,18 +245,20 @@
             // cbAutoPublish
             // 
             this.cbAutoPublish.AutoSize = true;
-            this.cbAutoPublish.Location = new System.Drawing.Point(12, 5);
+            this.cbAutoPublish.Location = new System.Drawing.Point(16, 6);
+            this.cbAutoPublish.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.cbAutoPublish.Name = "cbAutoPublish";
-            this.cbAutoPublish.Size = new System.Drawing.Size(119, 17);
+            this.cbAutoPublish.Size = new System.Drawing.Size(156, 21);
             this.cbAutoPublish.TabIndex = 7;
             this.cbAutoPublish.Text = "Publish after upload";
             this.cbAutoPublish.UseVisualStyleBackColor = true;
             // 
             // bCreateMapping
             // 
-            this.bCreateMapping.Location = new System.Drawing.Point(580, 5);
+            this.bCreateMapping.Location = new System.Drawing.Point(773, 6);
+            this.bCreateMapping.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.bCreateMapping.Name = "bCreateMapping";
-            this.bCreateMapping.Size = new System.Drawing.Size(156, 23);
+            this.bCreateMapping.Size = new System.Drawing.Size(208, 28);
             this.bCreateMapping.TabIndex = 6;
             this.bCreateMapping.Text = "Create Mapping File";
             this.bCreateMapping.UseVisualStyleBackColor = true;
@@ -261,19 +267,20 @@
             // comboBoxSelectedConnection
             // 
             this.comboBoxSelectedConnection.FormattingEnabled = true;
-            this.comboBoxSelectedConnection.Location = new System.Drawing.Point(12, 102);
+            this.comboBoxSelectedConnection.Location = new System.Drawing.Point(16, 126);
+            this.comboBoxSelectedConnection.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.comboBoxSelectedConnection.Name = "comboBoxSelectedConnection";
-            this.comboBoxSelectedConnection.Size = new System.Drawing.Size(297, 21);
+            this.comboBoxSelectedConnection.Size = new System.Drawing.Size(395, 24);
             this.comboBoxSelectedConnection.TabIndex = 5;
             this.comboBoxSelectedConnection.SelectedIndexChanged += new System.EventHandler(this.ComboBoxSelectedConnectionSelectedIndexChanged);
             // 
             // bPublish
             // 
             this.bPublish.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.bPublish.Location = new System.Drawing.Point(498, 105);
-            this.bPublish.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
+            this.bPublish.Location = new System.Drawing.Point(664, 129);
+            this.bPublish.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.bPublish.Name = "bPublish";
-            this.bPublish.Size = new System.Drawing.Size(74, 23);
+            this.bPublish.Size = new System.Drawing.Size(99, 28);
             this.bPublish.TabIndex = 3;
             this.bPublish.Text = "Publish";
             this.bPublish.UseVisualStyleBackColor = true;
@@ -283,23 +290,23 @@
             // 
             this.pnlMain.Controls.Add(this.lvConnections);
             this.pnlMain.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.pnlMain.Location = new System.Drawing.Point(0, 25);
-            this.pnlMain.Margin = new System.Windows.Forms.Padding(2);
+            this.pnlMain.Location = new System.Drawing.Point(0, 31);
+            this.pnlMain.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.pnlMain.Name = "pnlMain";
-            this.pnlMain.Padding = new System.Windows.Forms.Padding(4);
-            this.pnlMain.Size = new System.Drawing.Size(744, 251);
+            this.pnlMain.Padding = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            this.pnlMain.Size = new System.Drawing.Size(992, 309);
             this.pnlMain.TabIndex = 6;
             // 
             // ConnectionSelector
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.bCancel;
-            this.ClientSize = new System.Drawing.Size(744, 410);
+            this.ClientSize = new System.Drawing.Size(992, 505);
             this.Controls.Add(this.pnlMain);
             this.Controls.Add(this.pnlFooter);
             this.Controls.Add(this.menu);
-            this.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
+            this.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.Name = "ConnectionSelector";
             this.ShowIcon = false;
             this.Text = "Connection Manager";

--- a/CrmConnectionProjects/McTools.Xrm.Connection.WinForms/ConnectionSelector.resx
+++ b/CrmConnectionProjects/McTools.Xrm.Connection.WinForms/ConnectionSelector.resx
@@ -124,7 +124,7 @@
   <data name="tsbNewConnection.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIkSURBVDhPhVPbT5JhHP79Jd100U133XZjrnWwrrphq4u2
+        YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAAIkSURBVDhPhVPbT5JhHP79Jd100U133XZjrnWwrrphq4u2
         LlqnOWf1zbVVaBzkkHVRoEsh6LABzXQJRLnBQKaAoOVEIPZFU2OLgLRWrban9+f3CeVIn+3Zs+d3fN/v
         QJvotXt8vTYftDZvg+w5rpb8HzdsHp9zYgqBZA7+xBImBFnZc5zzamlrXLv7BOs/f6O2/gPVtSbZc5zz
         amlr9Aw8RkUU+xN5wRwCqrLnOOfV0taQrC6U69+QyFeQKgi++7yh7DnOebW0Na5YXFiurEE34ofBGYBR
@@ -139,7 +139,7 @@
   <data name="tsbUpdateConnection.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAI4SURBVDhPfZLLT5NREMX7N7gxLgmJLmRjjCtdaOLGuDNx
+        YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAAI4SURBVDhPfZLLT5NREMX7N7gxLgmJLmRjjCtdaOLGuDNx
         7UKjAqJB03xBVB6lpa0QIgtolEIpCoZWG0JoERcUkSIfWHmIUF4lPLRRHrUEH4nJzztQQWLrSU4mZ2bO
         mbu4hj8odbR6S2u9lNR6diha+smV9CiqbfW6OvoIDEbw65N0KEoVLX2ZJ1dTo/BBMxs/f7G+8YO1xC5F
         S1/mydXUKKh6wopa9utTihECySpa+jJPrqaGVukmFt9En1phaFpxZnWripa+Vtn0/wBjhZullQTmej/l
@@ -155,7 +155,7 @@
   <data name="tsbDeleteConnection.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAJKSURBVDhPhVPdS1NxGD5/QHQRdFWbWDcVFpVQKn0g3QXd
+        YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAAJKSURBVDhPhVPdS1NxGD5/QHQRdFWbWDcVFpVQKn0g3QXd
         VBfRhSVG9GGZpo0oKDV1TmdF5Nanc2bQ3Gku2kcLwaETt8amGc1t2TRWLJrb2Ag0a0/vbzu5FksfeHh4
         3s/zHs7h/qBBqdE2KLSoV/QtknkWF0r+j2sKjVZlsMH0xgujYxIGIlPmWZzlhdLcuHL7KRLzPxFNzCES
         z5B5Fmd5oTQ3Lt/sRZiKjQ4f0QuToMyzOMsLpbkhkasRin2HwxeG00/8MJtS5lmc5YXS3KhrVyMYjqPp

--- a/CrmConnectionProjects/McTools.Xrm.Connection.WinForms/ConnectionWizard2.cs
+++ b/CrmConnectionProjects/McTools.Xrm.Connection.WinForms/ConnectionWizard2.cs
@@ -94,9 +94,9 @@ namespace McTools.Xrm.Connection.WinForms
                 CrmConnectionDetail.ServerName = cfsc.HostName;
                 CrmConnectionDetail.ServerPort = cfsc.HostPort;
                 CrmConnectionDetail.OrganizationUrlName = cfsc.OrganizationUrlName;
-                CrmConnectionDetail.Timeout = cfsc.Timeout;
+                CrmConnectionDetail.TimeoutSpan = cfsc.Timeout;
 
-                if (CrmConnectionDetail.Timeout.Ticks == 0 || CrmConnectionDetail.ServerName == null)
+                if (CrmConnectionDetail.TimeoutSpan.Ticks == 0 || CrmConnectionDetail.ServerName == null)
                 {
                     return;
                 }
@@ -357,7 +357,7 @@ namespace McTools.Xrm.Connection.WinForms
                 }
 
                 CrmConnectionDetail.OriginalUrl = cuc.Url;
-                CrmConnectionDetail.Timeout = cuc.Timeout;
+                CrmConnectionDetail.TimeoutSpan = cuc.Timeout;
 
                 if (type == ConnectionType.Certificate)
                 {
@@ -614,7 +614,7 @@ namespace McTools.Xrm.Connection.WinForms
                 pnlFooter.Visible = true;
                 lblHeader.Text = @"General information and options";
 
-                var timespan = CrmConnectionDetail?.Timeout;
+                var timespan = CrmConnectionDetail?.TimeoutSpan;
                 if (!timespan.HasValue || timespan.Value.Ticks == 0)
                 {
                     timespan = new TimeSpan(0, 2, 0);

--- a/CrmConnectionProjects/McTools.Xrm.Connection.WinForms/McTools.Xrm.Connection.WinForms.csproj
+++ b/CrmConnectionProjects/McTools.Xrm.Connection.WinForms/McTools.Xrm.Connection.WinForms.csproj
@@ -61,7 +61,8 @@
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyOriginatorKeyFile>snk.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>
+    </AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -475,7 +476,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <None Include="snk.snk" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/CrmConnectionProjects/McTools.Xrm.Connection/ConnectionDetail.cs
+++ b/CrmConnectionProjects/McTools.Xrm.Connection/ConnectionDetail.cs
@@ -139,7 +139,7 @@ namespace McTools.Xrm.Connection
             }
         }
 
-        public async  Task<List<SolutionDetail>> GetSolutionsListAsync(bool forceNewService = false)
+        public async Task<List<SolutionDetail>> GetSolutionsListAsync(bool forceNewService = false)
         {
             var task = Task.Run(() => GetSolutionsList(forceNewService));
             return await task;
@@ -240,12 +240,14 @@ namespace McTools.Xrm.Connection
         }
 
         public Guid TenantId { get; set; }
-        public TimeSpan Timeout { get; set; }
+
+        [XmlIgnore]//renaming timeout to something different as in XML settings it comes as empty <Timeout/> node which is not deserializeable
+        public TimeSpan TimeoutSpan { get; set; }
 
         public long TimeoutTicks
         {
-            get { return Timeout.Ticks; }
-            set { Timeout = new TimeSpan(value); }
+            get { return TimeoutSpan.Ticks; }
+            set { TimeoutSpan = new TimeSpan(value); }
         }
 
         [XmlIgnore]
@@ -312,7 +314,7 @@ namespace McTools.Xrm.Connection
             set => ServerPort = string.IsNullOrEmpty(value) ? 80 : int.Parse(value);
         }
         public List<SolutionDetail> Solutions { get; set; }
-        
+
         public SolutionDetail SelectedSolution { get; set; }
         public string SolutionName { get => SelectedSolution == null ? "" : SelectedSolution.FriendlyName; }
 
@@ -331,11 +333,11 @@ namespace McTools.Xrm.Connection
             {
                 return crmSvc;
             }
-            if (Timeout.Ticks == 0)
+            if (TimeoutSpan.Ticks == 0)
             {
-                Timeout = new TimeSpan(0, 2, 0);
+                TimeoutSpan = new TimeSpan(0, 2, 0);
             }
-            CrmServiceClient.MaxConnectionTimeout = Timeout;
+            CrmServiceClient.MaxConnectionTimeout = TimeoutSpan;
 
             if (Certificate != null)
             {
@@ -587,7 +589,7 @@ namespace McTools.Xrm.Connection
             UserName = editedConnection.UserName;
             userPassword = editedConnection.userPassword;
             HomeRealmUrl = editedConnection.HomeRealmUrl;
-            Timeout = editedConnection.Timeout;
+            TimeoutSpan = editedConnection.TimeoutSpan;
             UseMfa = editedConnection.UseMfa;
             ReplyUrl = editedConnection.ReplyUrl;
             AzureAdAppId = editedConnection.AzureAdAppId;
@@ -803,7 +805,7 @@ namespace McTools.Xrm.Connection
                 userPassword = userPassword,
                 WebApplicationUrl = WebApplicationUrl,
                 OriginalUrl = OriginalUrl,
-                Timeout = Timeout,
+                TimeoutSpan = TimeoutSpan,
                 UseMfa = UseMfa,
                 AzureAdAppId = AzureAdAppId,
                 ReplyUrl = ReplyUrl,

--- a/CrmConnectionProjects/McTools.Xrm.Connection/ConnectionManager.cs
+++ b/CrmConnectionProjects/McTools.Xrm.Connection/ConnectionManager.cs
@@ -338,9 +338,9 @@ namespace McTools.Xrm.Connection
                         }
 
                         // Fix old connection for TimeOut
-                        if (detail.Timeout == TimeSpan.Zero)
+                        if (detail.TimeoutSpan == TimeSpan.Zero)
                         {
-                            detail.Timeout = new TimeSpan(1200000000);
+                            detail.TimeoutSpan = new TimeSpan(1200000000);
                         }
                     }
                 }

--- a/CrmConnectionProjects/McTools.Xrm.Connection/McTools.Xrm.Connection.csproj
+++ b/CrmConnectionProjects/McTools.Xrm.Connection/McTools.Xrm.Connection.csproj
@@ -224,7 +224,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties BuildVersion_StartDate="2012/1/1" BuildVersion_BuildVersioningStyle="None.None.DeltaBaseDate.Increment" BuildVersion_UpdateFileVersion="False" BuildVersion_UpdateAssemblyVersion="False" BuildVersion_ConfigurationName="Release" />
+      <UserProperties BuildVersion_ConfigurationName="Release" BuildVersion_UpdateAssemblyVersion="False" BuildVersion_UpdateFileVersion="False" BuildVersion_BuildVersioningStyle="None.None.DeltaBaseDate.Increment" BuildVersion_StartDate="2012/1/1" />
     </VisualStudio>
   </ProjectExtensions>
   <PropertyGroup>

--- a/CrmWebResourcesUpdater.Services/Helpers/MappingHelper.cs
+++ b/CrmWebResourcesUpdater.Services/Helpers/MappingHelper.cs
@@ -53,17 +53,18 @@ namespace CrmWebResourcesUpdater.Services.Helpers
                 projectFiles.RemoveAll(x => x.ToLower() == scriptPath);
                 mappingList.Add(scriptPath, webResourceName);
             }
-            foreach(var mapping in mappingList)
-            {
-                var scriptPath = mapping.Key;
-                var webResourceName = mapping.Value;
-                var projectMappingDublicates = projectFiles.Where(x => Path.GetFileName(x).ToLower() == webResourceName.ToLower());
-                if (projectMappingDublicates.Count() > 0)
-                {
-                    throw new ArgumentException("Project contains dublicate(s) for mapped web resource \"" + webResourceName + "\"");
-                }
+            //this bit totally fine when you have mapping for say uitls.js defined in mapping file and file on disk by the same name -> code below was throwing an error
+            //foreach(var mapping in mappingList)
+            //{
+            //    var scriptPath = mapping.Key;
+            //    var webResourceName = mapping.Value;
+            //    var projectMappingDublicates = projectFiles.Where(x => Path.GetFileName(x).ToLower() == webResourceName.ToLower());
+            //    if (projectMappingDublicates.Count() > 0)
+            //    {
+            //        throw new ArgumentException("Project contains duplicate(s) for mapped web resource \"" + webResourceName + "\"");
+            //    }
 
-            }
+            //}
             return mappingList;
         }
 

--- a/CrmWebResourcesUpdater.Services/PublishService.cs
+++ b/CrmWebResourcesUpdater.Services/PublishService.cs
@@ -261,8 +261,12 @@ namespace CrmWebResourcesUpdater.Services
                     var relativePath = lowerFilePath.Replace(projectRootPath + "\\", "");
                     await Logger.WriteLineAsync("Mapping found: " + relativePath + " to " + webResourceName, connections.ExtendedLog);
                 }
+                else
+                {
+                    await Logger.WriteLineAsync($"Mapping for not found for webresource {webResourceName} trying to find by name", connections.ExtendedLog);
+                }
 
-                var webResource = webResources.FirstOrDefault(x => x.GetAttributeValue<string>("name") == webResourceName);
+                var webResource = webResources.FirstOrDefault(x => x.GetAttributeValue<string>("name").ToLower() == webResourceName.ToLower());
                 if(webResource == null && connections.IgnoreExtensions)
                 {
                     await Logger.WriteLineAsync(webResourceName + " does not exists in selected solution", connections.ExtendedLog);


### PR DESCRIPTION
I installed visix and created connection, all worked fined until I deleted mapping file, then upon getting into Options over this particular solution error thrown out of VS, tried to debug seems multiple issues first it has <Timeout/> emtpy xml tag that it tries to deserialize into TimeSpan object and fails.

 [XmlIgnore]//renaming timeout to something different as in XML settings it comes as empty <Timeout/> node which is not deserializeable
public TimeSpan Timeout**Span** { get; set; }


Second code like that fixed to take into account null as SolutionId, without it failed with exception:
SelectedSolution = new SolutionDetail()
                {
                    FriendlyName = deprecatedConnection.SolutionFriendlyName,
                    PublisherPrefix = deprecatedConnection.PublisherPrefix,
                    SolutionId = **new Guid(deprecatedConnection.SolutionId ?? Guid.Empty.ToString()),**
                    UniqueName = deprecatedConnection.Solution
                }


in settings.cs
added exception handling as ConfigurationVersion property GetString throws exception for me
 private void Load()
        {

            CrmConnections = GetCrmConnections();
            SelectedConnectionId = _settingsStore.GetGuid(CollectionPath, SelectedConnectionIdPropertyName);
            **try
            {
                ConfigurationVersion = _settingsStore.GetString(CollectionPath, SettingsVersionPropertyName);
            }catch(Exception ex)
            {
                Logger.WriteLine($"Settings {SettingsVersionPropertyName} not found");
            }**
        }

Please test yourself, though it works for me now, not sure what side effects these changes can introduce