### PR TITLE
Added  build target arm64 to the vsix extension

### DIFF
--- a/Cwru.VsExtension/source.extension.vsixmanifest
+++ b/Cwru.VsExtension/source.extension.vsixmanifest
@@ -30,6 +30,15 @@
         <InstallationTarget Version="[16.0,17.0)" Id="Microsoft.VisualStudio.Enterprise">
             <ProductArchitecture>x86</ProductArchitecture>
         </InstallationTarget>
+        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Pro">
+            <ProductArchitecture>arm64</ProductArchitecture>
+        </InstallationTarget>
+        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
+            <ProductArchitecture>arm64</ProductArchitecture>
+        </InstallationTarget>
+        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
+            <ProductArchitecture>arm64</ProductArchitecture>
+        </InstallationTarget>
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.7.2,)" />


### PR DESCRIPTION
Hello,
first of all - thank you for this great tool!!!
I just added the build target arm64 to the extension so that I can use it on my arm based development machine.
The code is otherwise completely unchanged.
Greetings from Sweden!
Airic